### PR TITLE
Add embed mode for Google Sites sync

### DIFF
--- a/nav.js
+++ b/nav.js
@@ -1,5 +1,9 @@
 // Shared nav/theme/mobile-menu logic
 (function () {
+  // Embed mode: activate when loaded in an iframe or via ?embed=true
+  if (window !== window.top || new URLSearchParams(location.search).has('embed')) {
+    document.body.classList.add('embed-mode');
+  }
   // Theme
   const root = document.documentElement;
   const toggle = document.querySelector('[data-theme-toggle]');

--- a/style.css
+++ b/style.css
@@ -569,3 +569,12 @@ table { border-collapse: collapse; width: 100%; }
   font-style: italic; line-height: 1.7;
   margin: var(--space-6) 0;
 }
+
+/* ── EMBED MODE (Google Sites iframe) ───────────────────── */
+body.embed-mode .nav,
+body.embed-mode .mobile-menu,
+body.embed-mode .footer {
+  display: none !important;
+}
+body.embed-mode .hero { padding-top: var(--space-6); }
+body.embed-mode { overflow-x: hidden; }


### PR DESCRIPTION
## Summary
- Adds automatic iframe detection in `nav.js` — when the site is loaded inside an iframe (e.g., Google Sites embed), the nav bar and footer are hidden for a clean view
- Adds `?embed=true` query parameter support as a manual override
- CSS embed-mode rules in `style.css` hide navigation, mobile menu, and footer

## How to use with Google Sites
1. Open your Google Site in the editor
2. Go to **Insert > Embed > By URL**
3. Paste: `https://gsinchanpostdoc.github.io/Profile/index.html`
4. The site will automatically detect the iframe and show content without nav/footer

## Test plan
- [x] Open any page with `?embed=true` appended — nav and footer should be hidden
- [x] Open normally (no query param, not in iframe) — nav and footer should appear as usual
- [x] Embed the URL in a Google Sites page and verify clean display

🤖 Generated with [Claude Code](https://claude.com/claude-code)